### PR TITLE
chore(config): configurar CORS para permitir requisições do front-end

### DIFF
--- a/src/main/java/br/com/projeto/saude_plus/infra/cors/CorsConfig.java
+++ b/src/main/java/br/com/projeto/saude_plus/infra/cors/CorsConfig.java
@@ -1,0 +1,18 @@
+package br.com.projeto.saude_plus.infra.cors;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "TRACE", "CONNECT")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION

# 🔧 Configuração de CORS na API

## Descrição

Este pull request implementa a configuração de CORS na aplicação backend, permitindo que o front-end consiga realizar requisições HTTP à API de forma segura e controlada.

### 📌 O que foi feito

- Criada a classe `CorsConfig` com a anotação `@Configuration`.
- Adicionado mapeamento para todos os endpoints da API (`/**`).
- Permitido o domínio do front-end local (`http://localhost:5173`).
- Métodos HTTP permitidos: `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`, `HEAD`, `TRACE`, `CONNECT`.
- Permitidos todos os headers (`allowedHeaders("*")`).
- Habilitado suporte a cookies/autenticação via `allowCredentials(true)`.

### ✅ Observações

- Esta configuração é essencial para permitir que o front-end em React, hospedado em ambiente local, consiga se comunicar com a API durante o desenvolvimento.
- Em ambientes de produção, é recomendável restringir ainda mais os domínios permitidos por questões de segurança.
